### PR TITLE
calendar screen mockup structure

### DIFF
--- a/frontend/src/screens/Calendar/Calendar.css
+++ b/frontend/src/screens/Calendar/Calendar.css
@@ -1,12 +1,26 @@
 .calendar-screen {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     height: 100vh;
     background-color: white;
   }
+
+.calendar-month-view {
+    display: flex;
+  }
+
+.calendar-new-event {
+    display: flex;
+    
+  }
+
+.calendar-week-view {
+    display: flex;
+  }
   
-  h1 {
+h1 {
     font-size: 24px;
     color: #333;
   }

--- a/frontend/src/screens/Calendar/Calendar.js
+++ b/frontend/src/screens/Calendar/Calendar.js
@@ -4,7 +4,18 @@ import './Calendar.css';
 const Calendar = () => {
   return (
     <div className="calendar-screen">
-      <h1>Calendar Screen</h1>
+      <div className="calendar-title">
+        <h1>Calendar Screen</h1>
+      </div>
+      <div className="calendar-month-view">
+        <h1>Month View Screen</h1>
+      </div>
+      <div className="calendar-new-event">
+        <h1>New Event Screen</h1>
+      </div>
+      <div className="calendar-week-view">
+        <h1>Week View Screen</h1>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Added divs to create different sections for visual organization of the initial frontend mockup. Note that the edits will be made later such that the month view is automatically displayed, and the new event and week view pages are only displayed when certain onscreen elements are clicked.